### PR TITLE
fix(exports): node 13.0-13.6 require a string fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,14 +13,20 @@
     "url": "https://lukeed.com"
   },
   "exports": {
-    ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
-    },
-    "./sync": {
-      "import": "./sync/index.mjs",
-      "require": "./sync/index.js"
-    }
+    ".": [
+      {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.js"
+      },
+      "./dist/index.js"
+    ],
+    "./sync": [
+      {
+        "import": "./sync/index.mjs",
+        "require": "./sync/index.js"
+      },
+      "./sync/index.js"
+    ]
   },
   "files": [
     "*.d.ts",


### PR DESCRIPTION
package.json’s "engines" field claims cliui supports node >= 6; node v13.0-v13.6 are included in this semver range. This change is required to be able to require() from escalade successfully in these versions.

See https://github.com/yargs/yargs/pull/1776

I've manually tested this; it fixes the bug. Since the behavior can only be observed by installing escalade into a node_modules folder and then trying to `require` it, it's exceedingly difficult to test in CI.