### PR TITLE
fix(deno): specify import versions (avoids Deno warnings)

### DIFF
--- a/deno/async.ts
+++ b/deno/async.ts
@@ -1,4 +1,4 @@
-import { dirname, resolve } from 'https://deno.land/std/path/mod.ts'
+import { dirname, resolve } from 'https://deno.land/std@0.159.0/path/mod.ts'
 
 type Promisable<T> = T | Promise<T>;
 export type Callback = (directory: string, files: string[]) => Promisable<string | false | void>

--- a/deno/sync.ts
+++ b/deno/sync.ts
@@ -1,4 +1,4 @@
-import { dirname, resolve } from 'https://deno.land/std/path/mod.ts'
+import { dirname, resolve } from 'https://deno.land/std@0.159.0/path/mod.ts'
 
 export type Callback = (directory: string, files: string[]) => string | false | void;
 


### PR DESCRIPTION
The current version causes Deno to report warnings when imported...

```shell
$ deno run -q -r deno\async.ts
Warning Implicitly using latest version (0.159.0) for https://deno.land/std/path/mod.ts
$ deno run -q -r deno\sync.ts
Warning Implicitly using latest version (0.159.0) for https://deno.land/std/path/mod.ts
```

This pins the version to the current Deno std (0.159.0) for both scripts and removes the warnings.

```shell
$ deno run -q -r deno\async.ts
$ deno run -q -r deno\sync.ts
```